### PR TITLE
Fix includes and build

### DIFF
--- a/riscv/CMakeLists.txt
+++ b/riscv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.10)
 project(riscv C)
 
 set(CMAKE_C_STANDARD 11)

--- a/riscv/include/qpsk_mod.h
+++ b/riscv/include/qpsk_mod.h
@@ -1,6 +1,8 @@
 #ifndef QPSK_MOD_H
 #define QPSK_MOD_H
 
+#include <stdint.h>
+
 
 typedef struct {
     float real;

--- a/riscv/main.c
+++ b/riscv/main.c
@@ -1,9 +1,9 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include "src/rate_matching.c"
-#include  "src/qpsk_mod.c"
-#include "src/scrambler.c"
+#include "include/rate_matching.h"
+#include "include/qpsk_mod.h"
+#include "include/scrambler.h"
 
 #define LENGTH 4368
 

--- a/riscv/src/qpsk_mod.c
+++ b/riscv/src/qpsk_mod.c
@@ -1,6 +1,7 @@
 #include "../include/qpsk_mod.h"
 #include <math.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 void bi2de_pairs(const uint8_t *bits, int num_bits, uint8_t *out_symbols) {
     int num_symbols = num_bits / 2;


### PR DESCRIPTION
## Summary
- swap source includes for header includes in `main.c`
- lower CMake version requirement for compatibility
- ensure QPSK modules include stdint header

## Testing
- `cmake .. && make`

------
https://chatgpt.com/codex/tasks/task_e_684f80f3f7a0832ebe245bd8e653b945